### PR TITLE
Fix for string interpolation and db startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ docker compose up -d
 
 If you are getting blank dashboards, you can view logs with `docker compose logs` to check for any errors. Specifically: `docker compose logs frmcompanion` and `docker compose logs frmcache` as those are the two apps that are pulling data.
 
+Podman Compose has a hard time interpolating the environment variable strings.  If you are using Podman it is advised to use the official `docker-compose` binary instead of Podman's wrapper.
+
 ### Development
 
 You are able to run `docker compose build --no-cache` to build the local docker images.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,8 @@ services:
       - PG_USER=${PG_USER:-postgres}
       - PG_DB=${PG_DB:-postgres}
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
   postgres:
     image: postgres:17
     restart: unless-stopped
@@ -55,6 +56,11 @@ services:
       - POSTGRES_PASSWORD=${PG_PASSWORD:-secretpassword}
     volumes:
       - postgresql:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${PG_USER:-postgres}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   alertmanager-config:
     build: ./alertmanager-config

--- a/grafana/dashboards/players.json
+++ b/grafana/dashboards/players.json
@@ -420,7 +420,7 @@
           "format": "table",
           "hide": false,
           "rawQuery": true,
-          "rawSql": "SELECT (jsonb_array_elements(data -> 'Inventory') ->> 'Name') as NAME,\n(jsonb_array_elements(data -> 'Inventory') ->> 'Amount') as AMOUNT\n FROM cache where metric = 'player' and data ->> 'Name' in ($player) and url = '$server' and session_name = '$session';",
+          "rawSql": "SELECT (jsonb_array_elements(data -> 'Inventory') ->> 'Name') as NAME,\n(jsonb_array_elements(data -> 'Inventory') ->> 'Amount') as AMOUNT\n FROM cache where metric = 'player' and data ->> 'Name' in (${player:sqlstring}) and url = '$server' and session_name = '$session';",
           "refId": "A",
           "sql": {
             "columns": [


### PR DESCRIPTION
This PR has fixes for the following:

- Updated the Grafana player's query to be a `sqlstring` this fixes player names that include spaces
- Added a health check on the PostgreSQL container. This fixes an issue I was running into where the cache container wasn't fully waiting for the Postgres to start
- Added a comment in the README about Podman compose compatibility and how it is basically broken and you shouldn't use it.