### PR TITLE
fix(grafana): change maxOpenConns from 0 to 10 to avoir plugin erros

### DIFF
--- a/grafana/datasources/postgres.yml
+++ b/grafana/datasources/postgres.yml
@@ -10,7 +10,7 @@ datasources:
     jsonData:
       database: postgres
       sslmode: 'disable' # disable/require/verify-ca/verify-full
-      maxOpenConns: 0 # Grafana v5.4+
+      maxOpenConns: 10 # Grafana v5.4+
       maxIdleConns: 2 # Grafana v5.4+
       connMaxLifetime: 14400 # Grafana v5.4+
       postgresVersion: 1500 # 903=9.3, 904=9.4, 905=9.5, 906=9.6, 1000=10


### PR DESCRIPTION
Fixing :` errorMessageID=plugin.requestFailureError error="client: failed to query data: MaxSize must be >= 1" `
